### PR TITLE
feat: add /chathistory command

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -53,6 +53,7 @@ help_page_six = ("**Player Commands (Page 6/6):**\n\n" +
     "`/unlockexit <exit_name> <key_name>`\n Unlocks an exit in your current room using the specified key from your inventory.\n" +
     "`/roll <max_num> [passing_roll]`\n Rolls for a number between 1 and whatever you would like. If a passing roll is specified, also states whether the roll succeeds.\n" +
     "`/time`\n Checks the current time in roleplay.\n"
+    "`/chathistory`\n Gets the chat history of the last 5 minutes for the current room.\n"
     )
 
 helpPages = [help_page_one, help_page_two, help_page_three, help_page_four, help_page_five, help_page_six]

--- a/cogs/normal/etc.py
+++ b/cogs/normal/etc.py
@@ -1,11 +1,22 @@
+import io
 import random
 import datetime
 
+import chat_exporter
 from discord.ext import commands
 from discord import app_commands
 import discord
 
+import utils.data as data
 import utils.helpers as helpers
+
+
+class ChatHistoryButton(discord.ui.View):
+    def __init__(self, link: str):
+        super().__init__()
+
+        self.add_item(discord.ui.Button(label="View in Browser", url=link))
+
 
 class ETCCMDs(commands.Cog):
     def __init__(self, bot: commands.Bot):
@@ -59,6 +70,61 @@ class ETCCMDs(commands.Cog):
 
         await interaction.followup.send(f"`{current_time}`")
     #endregion
+
+    @app_commands.command(name="chathistory", description="Get the chat history of the last 5 minutes for the current room.")
+    async def chathistory(self, interaction: discord.Interaction):
+        await interaction.response.defer(thinking=True, ephemeral=True)
+        id = interaction.user.id
+        channel_id = interaction.channel_id
+        player = helpers.get_player_from_id(id)
+        currRoom = None
+
+        if await helpers.check_paused(player, interaction):
+            return
+        
+        if player is None or player.get_name() not in data.playerdata.keys():
+            await interaction.followup.send("*You are not a valid player. Please contact the admin if you believe this is a mistake.*")
+            return
+        
+        # we don't actually need the room, but we do need to check for it
+        for newRoom in data.roomdata.values():
+            if newRoom.get_id() == channel_id:
+                currRoom = newRoom
+
+        if currRoom is None:
+            await interaction.followup.send(
+                "*You are not currently in a room. Please contact an admin if you believe this is a mistake.*"
+            )
+            return
+        
+        now = discord.utils.utcnow().replace(microsecond=0)
+        messages: list[discord.Message] = []
+        
+        async for message in interaction.channel.history(limit=100, after=now - datetime.timedelta(minutes=5), oldest_first=False):
+            messages.append(message)
+            if message.author == self.bot.user and message.content.startswith(f"***{player.get_name()}** entered"):
+                break  # player has entered the room, so let's stop here
+
+        if not messages:
+            await interaction.followup.send("No messages found in the last 5 minutes.")
+            return
+
+        
+        transcript = await chat_exporter.raw_export(interaction.channel, messages, bot=self.bot)
+        transcript_file = discord.File(
+            io.BytesIO(transcript.encode()),
+            filename=f"chathistory-{interaction.channel.name}-{now.isoformat()}.html",
+        )
+
+        try:
+            reply = await interaction.user.send(f"Here is the chat history for the last 5 minutes in {interaction.channel.mention}.", file=transcript_file)
+            link = await chat_exporter.link(reply)
+            await reply.edit(view=ChatHistoryButton(link))
+
+            await interaction.followup.send("Chat history sent to your DMs.")
+        except discord.Forbidden:
+            await interaction.followup.send("Could not send you the chat history. Please make sure your DMs are open.")
+        
 
 async def setup(bot: commands.Bot):
     await bot.add_cog(ETCCMDs(bot))

--- a/cogs/normal/etc.py
+++ b/cogs/normal/etc.py
@@ -106,7 +106,7 @@ class ETCCMDs(commands.Cog):
                 break  # player has entered the room, so let's stop here
 
         if not messages:
-            await interaction.followup.send("No messages found in the last 5 minutes.")
+            await interaction.followup.send("*No messages found in the last 5 minutes.*")
             return
 
         
@@ -121,9 +121,9 @@ class ETCCMDs(commands.Cog):
             link = await chat_exporter.link(reply)
             await reply.edit(view=ChatHistoryButton(link))
 
-            await interaction.followup.send("Chat history sent to your DMs.")
+            await interaction.followup.send("*Chat history sent to your DMs.*")
         except discord.Forbidden:
-            await interaction.followup.send("Could not send you the chat history. Please make sure your DMs are open.")
+            await interaction.followup.send("*Could not send you the chat history. Please make sure your DMs are open.*")
         
 
 async def setup(bot: commands.Bot):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 discord.py<3
 python-dotenv
+chat-exporter


### PR DESCRIPTION
This PR adds a `/chathistory` commands that allows players to get a transcript of the last 5 minutes of message history of a room - useful for chat resets. This PR has a couple of limitations to prevent this from breaking the point of having rooms without message history (the intended use of this bot):
- As mentioned earlier, the messages have to be newer than 5 minutes.
- The bot will only get the last 100 messages in that time frame.
- The bot will not display messages that were present before the player entered the room.