### PR TITLE
feat: make/add scripts autoinstall python and deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Replace `your_bot_token` with the token you gained from the **Discord Developer 
 
 When saving the file, name it `.env` and select "All Files" as the file type rather than `.txt`. Do not include `.txt` at the end of the file name.
 
-On Windows, you can simply double click on `run.bat`.
+On Windows, you can simply double click on `run.bat` to start the bot.
 
 On Mac and Linux, you can run `run.sh` instead. This may require marking the script as executable.
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ This bot is not currently available via one singular invite link; unfortunately,
   - Use the generated URL to invite the bot to your server.
 
 ## Installation
-This bot requires [Python 3.10](https://www.python.org/downloads/release/python-3100/). You'll need to install the dependencies by opening Command Prompt in the same folder as `run.bat` and using 
-`pip install -r requirements.txt`.
+Download and extract (or `git clone`) this project. Downloading can be done by clicking on the "Code" button, then on "Download ZIP."
 
-Create a text document in the same folder. Inside, paste the following:
+Create a text document in the project folder. Inside, paste the following:
 ```
 guild_id=your_server_id
 token=your_bot_token
@@ -41,7 +40,9 @@ Replace `your_bot_token` with the token you gained from the **Discord Developer 
 
 When saving the file, name it `.env` and select "All Files" as the file type rather than `.txt`. Do not include `.txt` at the end of the file name.
 
-Start the bot with `run.bat`.
+On Windows, you can simply double click on `run.bat`.
+
+On Mac and Linux, you can run `run.sh` instead. This may require marking the script as executable.
 
 ## Server set up
 By this point, you should have your own custom roleplay bot on your server. What you do from here is entirely your choice—still, we'd like to give you a few tips on getting started with creating new environments.

--- a/run.bat
+++ b/run.bat
@@ -4,10 +4,10 @@ SETLOCAL ENABLEDELAYEDEXPANSION
 REM  uv is used here largely because it makes installation of Python easy.
 REM  At least, it is easier than installing Python manually.
 
-REM  Checks for existence of uv
+REM  Checks for existence of uv.
 TYPE %USERPROFILE%\.local\bin\uv.exe >nul 2>nul
 
-REM  If it doesn't exist, let's install uv
+REM  If it doesn't exist, let's install uv.
 REM  Installation is very simple (just run a command), but we do need to adjust
 REM  the execution policy to install it. We revert it back afterwards.
 REM  Note that the for statement here simply gets the current execution policy.

--- a/run.bat
+++ b/run.bat
@@ -1,3 +1,34 @@
 @echo off
-python main.py
-pause
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+REM  uv is used here largely because it makes installation of Python easy.
+REM  At least, it is easier than installing Python manually.
+
+REM  Checks for existence of uv
+TYPE %USERPROFILE%\.local\bin\uv.exe >nul 2>nul
+
+REM  If it doesn't exist, let's install uv
+REM  Installation is very simple (just run a command), but we do need to adjust
+REM  the execution policy to install it. We revert it back afterwards.
+ 
+IF %ERRORLEVEL% NEQ 0 (
+  FOR /F "tokens=* USEBACKQ" %%F IN (`powershell -c "Get-ExecutionPolicy -Scope CurrentUser"`) DO (SET CURSCOPE=%%F)
+  powershell -c "Set-ExecutionPolicy Bypass -scope CurrentUser"
+  powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+  powershell -c "Set-ExecutionPolicy !CURSCOPE! -scope CurrentUser"
+)
+
+
+REM  Simple check to see if uv has already installed a virtual environment.
+REM  uv does not work without it.
+DIR ".venv" >nul 2>nul
+
+IF %ERRORLEVEL% NEQ 0 (
+  %USERPROFILE%\.local\bin\uv venv --python 3.10
+)
+
+REM  From here, everything is relatively standard stuff, except we use uv.
+%USERPROFILE%\.local\bin\uv pip install -r requirements.txt
+
+%USERPROFILE%\.local\bin\uv run main.py
+PAUSE

--- a/run.bat
+++ b/run.bat
@@ -10,6 +10,7 @@ TYPE %USERPROFILE%\.local\bin\uv.exe >nul 2>nul
 REM  If it doesn't exist, let's install uv
 REM  Installation is very simple (just run a command), but we do need to adjust
 REM  the execution policy to install it. We revert it back afterwards.
+REM  Note that the for statement here simply gets the current execution policy.
  
 IF %ERRORLEVEL% NEQ 0 (
   FOR /F "tokens=* USEBACKQ" %%F IN (`powershell -c "Get-ExecutionPolicy -Scope CurrentUser"`) DO (SET CURSCOPE=%%F)
@@ -17,7 +18,6 @@ IF %ERRORLEVEL% NEQ 0 (
   powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
   powershell -c "Set-ExecutionPolicy !CURSCOPE! -scope CurrentUser"
 )
-
 
 REM  Simple check to see if uv has already installed a virtual environment.
 REM  uv does not work without it.

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# uv is used here largely because it makes installation of Python easy.
+# At least, it is easier than installing Python manually.
+
+# If uv doesn't exist, let's install uv. Installation is thankfully simple.
+if ! [ -x "$(command -v uv)" ]; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+
+# Simple check to see if uv has already installed a virtual environment.
+# uv does not work without it.
+if [ ! -d ".venv" ]; then
+  uv venv --python 3.10
+fi
+
+# From here, everything is relatively standard stuff, except we use uv.
+uv pip install -r requirements.txt
+uv run main.py
+
+read -p "Press enter to continue."


### PR DESCRIPTION
This PR adjusts `run.bat` to automatically install Python 3.10 and install dependencies, and adds an equivalent `run.sh` for MacOS/Linux users. This PR also adjusts the installation section for the README.

[uv](https://docs.astral.sh/uv/) is used because it makes installing Python from a command line/terminal easy and relatively OS-independent (once uv is installed). It's also *absurdly* fast at installing packages, which is a plus.

MacOS has not been tested, but it's not like either of us could 😅.