### PR TITLE
Display objects

### DIFF
--- a/cogs/admin/objects.py
+++ b/cogs/admin/objects.py
@@ -231,17 +231,16 @@ class AdminObjectsCMDs(commands.Cog):
             return
 
         if not hasattr(searchedObj, "isDisplay"):
-            updatedObj = copy.deepcopy(searchedObj)
-            updatedObj.isDisplay = False
-            if not hasattr(updatedObj, "get_display_state"):
+            searchedObj.isDisplay = False
+            if not hasattr(searchedObj, "get_display_state"):
                 def get_display_state(self):
                     return self.isDisplay
                 def set_display_state(self, display: bool):
                     self.isDisplay = display
                     return
-                updatedObj.get_display_state = get_display_state.__get__(updatedObj)
-                updatedObj.set_display_state = set_display_state.__get__(updatedObj)
-            searchedObj.__dict__.update(updatedObj.__dict__)
+                searchedObj.get_display_state = get_display_state.__get__(searchedObj)
+                searchedObj.set_display_state = set_display_state.__get__(searchedObj)
+            searchedObj.__dict__.update(searchedObj.__dict__)
 
         output_str: typing.List[str] = []
         if new_name != '':

--- a/cogs/normal/objects.py
+++ b/cogs/normal/objects.py
@@ -198,6 +198,7 @@ class ObjectCMDs(commands.Cog):
             return
 
         is_locked = 'Locked' if searchedObj.get_locked_state() else 'Opened'
+        is_display = searchedObj.get_display_state() if hasattr(searchedObj, "isDisplay") else False
 
         storage_amt = ''
         used_storage = ''
@@ -212,11 +213,11 @@ class ObjectCMDs(commands.Cog):
             if searchedObj.get_container_state():
                 if searchedObj.get_desc() == '':
                     await interaction.followup.send(
-                        f"***{player.get_name()}** looked at the object **{searchedObj.get_name()}**:*\n\n__`{searchedObj.get_name()}`__\n\n__`Storage`__: `{used_storage}{storage_amt}`\n__`State`__: `{is_locked}`\n\n`Object has no description.`"
+                        f"***{player.get_name()}** looked at the object **{searchedObj.get_name()}**:*\n\n__`{searchedObj.get_name()}`__\n\n__`Storage`__: `{used_storage}{storage_amt}`\n__`State`__: `{is_locked}`\n__`Display`__: `{is_display}`\n\n`Object has no description.`"
                     )
                     return
                 await interaction.followup.send(
-                    f"***{player.get_name()}** looked at the object **{searchedObj.get_name()}**:*\n\n__`{searchedObj.get_name()}`__\n\n__`Storage`__: `{used_storage}{storage_amt}`\n__`State`__: `{is_locked}`\n\n{searchedObj.get_desc()}"
+                    f"***{player.get_name()}** looked at the object **{searchedObj.get_name()}**:*\n\n__`{searchedObj.get_name()}`__\n\n__`Storage`__: `{used_storage}{storage_amt}`\n__`State`__: `{is_locked}`\n__`Display`__: `{is_display}`\n\n{searchedObj.get_desc()}"
                 )
                 return
             if searchedObj.get_desc() == '':
@@ -229,11 +230,11 @@ class ObjectCMDs(commands.Cog):
         if containerState == True:
             if searchedObj.get_desc() == '':
                 await interaction.followup.send(
-                    f"*Looked at the object **{searchedObj.get_name()}**:*\n\n__`{searchedObj.get_name()}`__\n\n__`Storage`__: `{storage_amt}`\n__`State`__: `{is_locked}`\n\n`Object has no description.`"
+                    f"*Looked at the object **{searchedObj.get_name()}**:*\n\n__`{searchedObj.get_name()}`__\n\n__`Storage`__: `{storage_amt}`\n__`State`__: `{is_locked}`\n__`Display`__: `{is_display}`\n\n`Object has no description.`"
                 )
                 return
             await interaction.followup.send(
-                f"*Looked at the object **{searchedObj.get_name()}**:*\n\n__`{searchedObj.get_name()}`__\n\n__`Storage`__: `{storage_amt}`\n__`State`__: `{is_locked}`\n\n{searchedObj.get_desc()}"
+                f"*Looked at the object **{searchedObj.get_name()}**:*\n\n__`{searchedObj.get_name()}`__\n\n__`Storage`__: `{storage_amt}`\n__`State`__: `{is_locked}`\n__`Display`__: `{is_display}`\n\n{searchedObj.get_desc()}"
             )
             return
 
@@ -270,6 +271,8 @@ class ObjectCMDs(commands.Cog):
             await interaction.followup.send(f"*Could not find the object **{object_name}**. Please use `/objects` to see a list of all the objects in the current room.*")
             return
 
+        is_display = searchedObj.get_display_state() if hasattr(searchedObj, "isDisplay") else False
+
         if not searchedObj.get_container_state():
             if player is not None:
                 await interaction.followup.send(f"***{player.get_name()}** tried to look inside of the object **{searchedObj.get_name()}**, but it was not a container.*")
@@ -277,12 +280,13 @@ class ObjectCMDs(commands.Cog):
             await interaction.followup.send(f"*Tried to look inside of the object **{searchedObj.get_name()}**, but it was not a container.*")
             return
 
-        if searchedObj.get_locked_state():
+        if searchedObj.get_locked_state() and not is_display:
             if player is not None:
                 await interaction.followup.send(f"***{player.get_name()}** tried to look inside of the object **{searchedObj.get_name()}**, but it was locked.*")
                 return
             await interaction.followup.send(f"*Tried to look inside of the object **{searchedObj.get_name()}**, but it was locked.*")
             return
+            
 
         itemList = searchedObj.get_items()
         if len(itemList) == 0:
@@ -327,6 +331,8 @@ class ObjectCMDs(commands.Cog):
             await interaction.followup.send(f"*Could not find the object **{object_name}**. Please use `/objects` to see a list of all the objects in the current room.*")
             return
 
+        is_display = searchedObj.get_display_state() if hasattr(searchedObj, "isDisplay") else False
+
         if not searchedObj.get_container_state():
             if player is not None:
                 await interaction.followup.send(f"***{player.get_name()}** tried to look inside of the object **{searchedObj.get_name()}**, but it was not a container.*")
@@ -334,7 +340,7 @@ class ObjectCMDs(commands.Cog):
             await interaction.followup.send(f"*Tried to look inside of the object **{searchedObj.get_name()}**, but it was not a container.*")
             return
 
-        if searchedObj.get_locked_state():
+        if searchedObj.get_locked_state() and not is_display:
             if player is not None:
                 await interaction.followup.send(f"***{player.get_name()}** tried to look inside of the object **{searchedObj.get_name()}**, but it was locked.*")
                 return

--- a/cogs/normal/objects.py
+++ b/cogs/normal/objects.py
@@ -517,7 +517,7 @@ class ObjectCMDs(commands.Cog):
 
         if searchedObj.get_locked_state():
             await interaction.followup.send(
-                f"`{player.get_name()}` tried to drop an item inside of the object `{searchedObj.get_name()}`, but it was locked."
+                f"***{player.get_name()}** tried to drop an item inside of the object **{searchedObj.get_name()}**, but it was locked.*"
             )
             return
 

--- a/utils/autocompletes.py
+++ b/utils/autocompletes.py
@@ -187,13 +187,15 @@ async def object_contents_autocomplete(interaction: discord.Interaction, item_na
         if helpers.simplify_string(object.get_name()) == helpers.simplify_string(object_name):
             searchedObj = object
 
+    is_display = searchedObj.get_display_state() if hasattr(searchedObj, "isDisplay") else False
+
     if searchedObj is None:
         return []
 
     if not searchedObj.get_container_state():
         return []
 
-    if searchedObj.get_locked_state():
+    if searchedObj.get_locked_state() and not is_display:
         return []
 
     itemList = searchedObj.get_items()

--- a/utils/data.py
+++ b/utils/data.py
@@ -43,11 +43,12 @@ class Item:
 #endregion
 #region Object
 class Object:
-    def __init__(self, name: str, isContainer: bool, isLocked: bool, keyName: str = '', storage: int = -1, desc: str = ''):
+    def __init__(self, name: str, isContainer: bool, isLocked: bool, isDisplay: bool, keyName: str = '', storage: int = -1, desc: str = ''):
         self.name = name
         self.desc = desc
         self.isContainer = isContainer
         self.isLocked = isLocked
+        self.isDisplay = isDisplay
         self.keyName = keyName
         self.storage = storage
         self.objItems: typing.List[Item] = []
@@ -73,12 +74,23 @@ class Object:
     def get_storage(self):
         return self.storage
 
+    def set_display_state(self, display: bool):
+        self.isDisplay = display
+        return
+
+    def get_display_state(self):
+        return self.isDisplay
+
     def switch_locked_state(self, locked: bool):
         self.isLocked = locked
         return
 
     def switch_container_state(self, container: bool):
         self.isContainer = container
+        return
+
+    def set_items(self, items: typing.List[Item]):
+        self.objItems = items
         return
 
     def add_item(self, item: Item):


### PR DESCRIPTION
- objects have a new "display" property, allowing players to see inside of them even if they're locked if it's set to true
- a few workarounds exist for objects that don't have the display attribute; should go back and delete them after ARX is over