### PR TITLE
fix: use new view in browser link for /chathistory

### DIFF
--- a/cogs/admin/items.py
+++ b/cogs/admin/items.py
@@ -40,6 +40,7 @@ class AdminItemsCMDs(commands.Cog):
         currentWeight = 0
         capacity = 0
         checkCapacity = False
+        desc = helpers.format_desc(desc)
 
         if item_name.startswith("\\"):
             await interaction.followup.send(f"*You did not enter a valid item name. Please do not start a name with a backslash.*")
@@ -510,6 +511,7 @@ class AdminItemsCMDs(commands.Cog):
             nameStr = 'name'
             item_strs.append(nameStr)
         if new_desc != '':
+            new_desc = helpers.format_desc(new_desc)
             searchedItem.edit_desc(new_desc)
             descStr = 'description'
             item_strs.append(descStr)

--- a/cogs/admin/objects.py
+++ b/cogs/admin/objects.py
@@ -38,6 +38,8 @@ class AdminObjectsCMDs(commands.Cog):
             await interaction.followup.send(f"*Room **{room_name}** could not be found. Please use `/listrooms` to see all current rooms.*")
             return
         
+        desc = helpers.format_desc(desc)
+
         object: data.Object = data.Object(object_name, is_container, is_locked, is_display, key_name, storage, desc)
         room.add_object(object)
 
@@ -247,6 +249,7 @@ class AdminObjectsCMDs(commands.Cog):
             searchedObj.edit_name(new_name)
             output_str.append("name")
         if new_desc != '':
+            new_desc = helpers.format_desc(new_desc)
             searchedObj.edit_desc(new_desc)
             output_str.append("description")
         if new_container_state != None:

--- a/cogs/admin/players.py
+++ b/cogs/admin/players.py
@@ -47,6 +47,8 @@ class AdminPlayerCMDs(commands.Cog):
             )
             return
 
+        desc = helpers.format_desc(desc)
+
         data.playerdata[player_name] = data.Player(player_name, player_id, desc)
         data.save()
         await interaction.followup.send(
@@ -121,6 +123,7 @@ class AdminPlayerCMDs(commands.Cog):
             del data.playerdata[old_name]
             edited += f" name to **{new_name}**"
         if new_desc != '':
+            new_desc = helpers.format_desc(new_desc)
             player.edit_desc(new_desc)
             if edited == '':
                 edited = f'{edited} description'

--- a/cogs/admin/rooms.py
+++ b/cogs/admin/rooms.py
@@ -45,6 +45,8 @@ class AdminRoomCMDs(commands.Cog):
                 )
                 return
 
+        desc = helpers.format_desc(desc)
+
         data.roomdata[room_name] = data.Room(room_name, room_id, desc)
         channel = self.bot.get_channel(room_id)
         if (desc != ''):
@@ -327,6 +329,7 @@ class AdminRoomCMDs(commands.Cog):
             del data.roomdata[old_name]
             edited += f" name to **{new_name}**"
         if new_desc != '':
+            new_desc = helpers.format_desc(new_desc)
             room.edit_desc(new_desc)
             channel = self.bot.get_channel(int(room_id))
             await channel.edit(topic=new_desc)

--- a/cogs/normal/etc.py
+++ b/cogs/normal/etc.py
@@ -123,7 +123,7 @@ class ETCCMDs(commands.Cog):
 
         try:
             reply = await interaction.user.send(f"Here is the chat history for the last 5 minutes in {interaction.channel.mention}.", file=transcript_file)
-            link = await chat_exporter.link(reply)
+            link = f"{os.environ["CHATHISTORY_BASE_URL"]}{reply.attachments[0].url}"
             await reply.edit(view=ChatHistoryButton(link))
 
             await interaction.followup.send("*Chat history sent to your DMs.*")

--- a/cogs/normal/etc.py
+++ b/cogs/normal/etc.py
@@ -123,7 +123,7 @@ class ETCCMDs(commands.Cog):
 
         try:
             reply = await interaction.user.send(f"Here is the chat history for the last 5 minutes in {interaction.channel.mention}.", file=transcript_file)
-            link = f"{os.environ["CHATHISTORY_BASE_URL"]}{reply.attachments[0].url}"
+            link = f"{os.environ['CHATHISTORY_BASE_URL']}{reply.attachments[0].url}"
             await reply.edit(view=ChatHistoryButton(link))
 
             await interaction.followup.send("*Chat history sent to your DMs.*")

--- a/main.py
+++ b/main.py
@@ -37,6 +37,9 @@ def get_all_extensions(str_path: str, folder: str = "cogs") -> list[str]:
 load_dotenv()
 GUILD = discord.Object(id=int(os.environ['guild_id']))
 
+if not os.environ.get("CHATHISTORY_BASE_URL"):
+    os.environ["CHATHISTORY_BASE_URL"] = "https://basic-discord-html-viewer.onrender.com/display?url="
+
 class Client(commands.Bot):
     def __init__(self, *, intents:discord.Intents):
         super().__init__(intents=intents, command_prefix="/")

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -3,9 +3,8 @@ import discord
 
 from utils.data import Player, Room, Item, playerdata, roomdata
 
-def simplify_string(string: str) -> str:
-    return string.replace(' ', '').lower()
-#endregion
+
+
 
 #region Get Player methods
 
@@ -24,6 +23,7 @@ def get_player_from_name(name: str) -> typing.Optional[Player]:
 
 #endregion
 
+
 #region Get Room methods
 
 #region Get room from ID
@@ -38,6 +38,11 @@ def get_room_from_name(name: str) -> typing.Optional[Room]:
         if simplify_string(room.get_name()) == simplify_string(name):
             return room
 #endregion
+
+#endregion
+
+
+#region Miscellaneous methods
 
 #region Find items with shared name
 
@@ -70,11 +75,24 @@ def find_items(name: str) -> typing.List[typing.Tuple[Item, str]]:
     return foundItems
 
 #endregion
-
 #region Check if player is paused
 async def check_paused(player: typing.Optional[Player], interaction: discord.Interaction) -> bool:
     if player is not None and player.is_paused():
         await interaction.followup.send(content="*Player commands are currently paused. Please wait until the admin unpauses your ability to use player commands.*", ephemeral=True)
         return True
     return False
+#endregion
+#region Simplify string
+def simplify_string(string: str) -> str:
+    return string.replace(' ', '').lower()
+#endregion
+#region Format description
+def format_desc(desc: str) -> str:
+    lines = desc.split('\\n')
+    formattedDesc = ''
+    for line in lines:
+        formattedDesc += (line + '\n')
+    return formattedDesc
+#endregion
+
 #endregion


### PR DESCRIPTION
This title fixes `/chathistory`'s "View in Browser" button.

Around the end of March, the feature in the library we were using that allowed for this was disabled, and users would get directed to a webpage saying as such rather than being able to view chat history. I quickly whipped up [a small program](https://github.com/AstreaTSS/basic-discord-html-viewer) that replicated the old feature, and all this PR is use a running instance of that.

This freely hosted instance is hosted on [Render](https://render.com/)'s free tier, which means it shuts off automatically every once in a while, requiring a 30 sec - 1 minute boot up time when that happens. If someone doesn't want this downside, they can easily host the program and set the `CHATHISTORY_BASE_URL` environmental variable.